### PR TITLE
Create output directories and CACHEDIR.TAG files on the fly

### DIFF
--- a/Run2Mechanism/README.md
+++ b/Run2Mechanism/README.md
@@ -259,7 +259,8 @@ When using Condor on cmslpc, the CMSSW working directory is sent to the worker n
 Some subdirectories only contain log files or LHE output files which are not necessary to run the production.
 The user can exclude such a subdirectory by placing a file called CACHEDIR.TAG in it.
 The tar option `--exclude-caches-all` (used by default in [run_scan.py](./run_scan.py)) will then ignore the subdirectory.
-Examples of this CACHEDIR.TAG file are included in the repository for the lhe, lhe_processed, logs, and scripts directories.
+[run_scan.py](./run_scan.py) will automatically create a CACHEDIR.TAG file in the lhe, lhe_processed, logs, and scripts directories
+(or the user-specified local output directory, if it is different than the default "lhe").
 For more about CACHEDIR.TAG, consult the [Cache Directory Tagging Standard](http://www.brynosaurus.com/cachedir/spec.html).
 
 By default the script will submit to the 1nd queue when using the lxplus batch system. Depending on how many events you want

--- a/Run2Mechanism/SUSY_generation.sh
+++ b/Run2Mechanism/SUSY_generation.sh
@@ -76,8 +76,8 @@ else
     fi
   else
     echo "mv output for lxbatch"
-    mkdir -p ${OUTDIR}
-    mv Events/pilotrun/unweighted_events.lhe.gz ${OUTDIR}/${CUSTOMCARD}_undecayed.lhe.gz
+    mkdir -p ../${OUTDIR}
+    mv -v Events/pilotrun/unweighted_events.lhe.gz ../${OUTDIR}/${CUSTOMCARD}_undecayed.lhe.gz
   fi
   
   echo "End of job"

--- a/Run2Mechanism/jobExecLXbatch.sh
+++ b/Run2Mechanism/jobExecLXbatch.sh
@@ -14,5 +14,5 @@ source RUNDIR/setupGenEnv.sh
 
 # run madgraph
 ${RUNBASEDIR}/SUSY_generation.sh ${RUNBASEDIR}/cards OUTDIR PROCNAME CUSTOMCARD
-
-
+cp -v OUTDIR/CUSTOMCARD_undecayed.lhe.gz ${RUNBASEDIR}/OUTDIR
+rm -rf OUTDIR

--- a/Run2Mechanism/lhe/CACHEDIR.TAG
+++ b/Run2Mechanism/lhe/CACHEDIR.TAG
@@ -1,4 +1,0 @@
-Signature: 8a477f597d28d172789f06886806bc55
-# This file is a cache directory tag.
-# For information about cache directory tags, see:
-#	http://www.brynosaurus.com/cachedir/

--- a/Run2Mechanism/lhe_processed/CACHEDIR.TAG
+++ b/Run2Mechanism/lhe_processed/CACHEDIR.TAG
@@ -1,4 +1,0 @@
-Signature: 8a477f597d28d172789f06886806bc55
-# This file is a cache directory tag.
-# For information about cache directory tags, see:
-#	http://www.brynosaurus.com/cachedir/

--- a/Run2Mechanism/logs/CACHEDIR.TAG
+++ b/Run2Mechanism/logs/CACHEDIR.TAG
@@ -1,4 +1,0 @@
-Signature: 8a477f597d28d172789f06886806bc55
-# This file is a cache directory tag.
-# For information about cache directory tags, see:
-#	http://www.brynosaurus.com/cachedir/

--- a/Run2Mechanism/run_scan.py
+++ b/Run2Mechanism/run_scan.py
@@ -271,7 +271,8 @@ if __name__ == "__main__":
     for dirname in dirlist:
         if not os.path.isdir(RUNDIR+"/"+dirname):
             os.mkdir(RUNDIR+"/"+dirname)
-        cachedir(RUNDIR+"/"+dirname)
+        if args.protocol == "condor":
+            cachedir(RUNDIR+"/"+dirname)
 
     # print the command line arguments for provenance
     print_configuration(vars(args))

--- a/Run2Mechanism/run_scan.py
+++ b/Run2Mechanism/run_scan.py
@@ -167,7 +167,7 @@ def makejob(PROTOCOL, RUNDIR, CMSSWBASE, CMSSWVER, PROCNAME, OUTDIR, NEV, NRUN, 
     
     jobname = jobprefix+"_"+customname+jobsuffix
     # these initial commands are common to condor and lxbatch
-    jobcmd = "cat "+jobprefix+jobsuffix+" | sed -e s/CUSTOMCARD/"+customname+"/ | sed -e s/CMSSWVER/"+CMSSWVER+"/ | sed -e s~OUTDIR~"+OUTDIR+"~ | sed -e s/PROCNAME/"+PROCNAME+"/"
+    jobcmd = "cat "+jobprefix+jobsuffix+" | sed -e s/CUSTOMCARD/"+customname+"/ | sed -e s/CMSSWVER/"+CMSSWVER+"/ | sed -e s~OUTDIR~"+OUTDIR+"~g | sed -e s/PROCNAME/"+PROCNAME+"/"
     # lxbatch needs some extra directory info because it doesn't use the CMSSW tarball
     if PROTOCOL == "bsub" or PROTOCOL == "qsub":
         jobcmd = jobcmd+" | sed -e s~CMSDIR~"+CMSSWBASE+"~ | sed -e s~RUNDIR~"+RUNDIR+"~"

--- a/Run2Mechanism/run_scan.py
+++ b/Run2Mechanism/run_scan.py
@@ -196,8 +196,8 @@ def makejob(PROTOCOL, RUNDIR, CMSSWBASE, CMSSWVER, PROCNAME, OUTDIR, NEV, NRUN, 
 # -----------------------------------------------------------------
 def submitjob(QUEUE, JOBNAME, RUNDIR, PROTOCOL, NCORES):
     # location to store error and log files
-    errorfile = RUNDIR + "/log/" + JOBNAME.split("/")[-1].replace(".sh",".err")
-    logfile = RUNDIR + "/log/" + JOBNAME.split("/")[-1].replace(".sh",".log")
+    errorfile = os.path.join(RUNDIR,"logs",JOBNAME.split("/")[-1].replace(".sh",".err"))
+    logfile = os.path.join(RUNDIR,"logs",JOBNAME.split("/")[-1].replace(".sh",".log"))
     # submit the job based on the specified protocol
     submitcommand = ""
     if PROTOCOL == "bsub":
@@ -208,7 +208,7 @@ def submitjob(QUEUE, JOBNAME, RUNDIR, PROTOCOL, NCORES):
         if NCORES > 1:
             submitcommand.extend(["-n %s" % (NCORES),
                                   "-R span[hosts=1]"])
-        submitcommand.append(JOBNAME)
+        submitcommand.append(os.path.join(RUNDIR,"scripts",JOBNAME))
         print ' '.join(submitcommand)
 
     elif PROTOCOL == "qsub": 
@@ -216,11 +216,11 @@ def submitjob(QUEUE, JOBNAME, RUNDIR, PROTOCOL, NCORES):
                          "-q %s" % (QUEUE),
                          "-e %s" % (errorfile),
                          "-o %s" % (logfile),
-                         JOBNAME] 
+                         os.path.join(RUNDIR,"scripts",JOBNAME)] 
         print ' '.join(submitcommand)
         
     elif PROTOCOL == "condor":
-        submitcommand = ["condor_submit", os.getenv("PWD")+"/scripts/"+JOBNAME]
+        submitcommand = ["condor_submit", os.path.join(RUNDIR,"scripts",JOBNAME)]
         print ' '.join(submitcommand)
 
     else: 

--- a/Run2Mechanism/scripts/CACHEDIR.TAG
+++ b/Run2Mechanism/scripts/CACHEDIR.TAG
@@ -1,4 +1,0 @@
-Signature: 8a477f597d28d172789f06886806bc55
-# This file is a cache directory tag.
-# For information about cache directory tags, see:
-#	http://www.brynosaurus.com/cachedir/


### PR DESCRIPTION
@ferencek: this PR should take care of all the CACHEDIR.TAG stuff.

`run_scan.py` now automatically creates the scripts, logs, lhe, and lhe_processed directories, and adds CACHEDIR.TAG files to them if necessary. If the user-specified local output directory is different from "lhe", it will instead create $OUTPUT and $OUTPUT_processed directories.