### PR TITLE
fix cards directory in SUSY_gen script

### DIFF
--- a/Run2Mechanism/SUSY_generation.sh
+++ b/Run2Mechanism/SUSY_generation.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CARDSDIR=$1
+CARDSDIR=${RUNBASEDIR}/$1
 OUTDIR=$2
 PROCNAME=$3
 CUSTOMCARD=$4
@@ -18,7 +18,9 @@ fi
 ${MGBASEDIR}/bin/mg5_aMC ${CARDSDIR}/${PROCNAME}_proc_card.dat
 
 # move generic process directory to specific custom directory for this job
-mv ${PROCNAME} ${CUSTOMCARD}
+if [ "$PROCNAME" != "$CUSTOMCARD" ]; then
+  mv -v ${PROCNAME} ${CUSTOMCARD}
+fi
 cd ${CUSTOMCARD}
 
 # Locating the run card
@@ -72,7 +74,7 @@ else
       xrdcp -f Events/pilotrun/unweighted_events.lhe.gz ${OUTDIR}/${CUSTOMCARD}_undecayed.lhe.gz
     else
       #transfer output using condor file transfer
-      mv Events/pilotrun/unweighted_events.lhe.gz ${CMSSW_BASE}/../${CUSTOMCARD}_undecayed.lhe.gz
+      mv -v Events/pilotrun/unweighted_events.lhe.gz ${CMSSW_BASE}/../${CUSTOMCARD}_undecayed.lhe.gz
     fi
   else
     echo "mv output for lxbatch"

--- a/Run2Mechanism/jobExecCondor.sh
+++ b/Run2Mechanism/jobExecCondor.sh
@@ -33,7 +33,8 @@ cd -
 source setupGenEnv.sh
 
 # cardfiles location
-CARDSDIR=${RUNBASEDIR}/cards
+# will be prepended with ${RUNBASEDIR}/ in SUSY_generation.sh
+CARDSDIR=cards
 
 # run madgraph
 # last argument specifies that the script is running in Condor

--- a/Run2Mechanism/jobExecLXbatch.sh
+++ b/Run2Mechanism/jobExecLXbatch.sh
@@ -13,6 +13,6 @@ cd -
 source RUNDIR/setupGenEnv.sh
 
 # run madgraph
-${RUNBASEDIR}/SUSY_generation.sh ${RUNBASEDIR}/cards OUTDIR PROCNAME CUSTOMCARD
+${RUNBASEDIR}/SUSY_generation.sh cards OUTDIR PROCNAME CUSTOMCARD
 cp -v OUTDIR/CUSTOMCARD_undecayed.lhe.gz ${RUNBASEDIR}/OUTDIR
 rm -rf OUTDIR


### PR DESCRIPTION
This PR fixes an issue with using SUSY_generation.sh interactively, as recently noted by a user.

Previously, the cards directory was prepended with the full running directory only in the batch executables. Now, this preprending is done in SUSY_generation.sh itself, so it will work interactively as well.

Also, an 'mv' command was made slightly smarter, and all the 'mv' commands were set to verbose mode (for easier future debugging).